### PR TITLE
Optimizations

### DIFF
--- a/domain/Context.go
+++ b/domain/Context.go
@@ -15,7 +15,7 @@ func NewEmptyContext() *Context {
 	return &Context{
 		Clock:       VectorClock{},
 		GoroutineID: GoroutineCounter.GetNext(),
-		StackTrace:  stacks.NewIntStackWithMap(),
+		StackTrace:  stacks.NewEmptyIntStackWithMap(),
 	}
 }
 
@@ -54,6 +54,6 @@ func (gs *Context) CopyWithoutMap() *Context {
 	return &Context{
 		GoroutineID: gs.GoroutineID,
 		Clock:       gs.Clock.Copy(),
-		StackTrace:  stacks.NewIntStackWithMapWithParams(*gs.StackTrace.GetItems().Copy(), nil),
+		StackTrace:  stacks.NewIntStackWithMap(*gs.StackTrace.GetItems().Copy(), nil),
 	}
 }

--- a/domain/Context.go
+++ b/domain/Context.go
@@ -1,6 +1,6 @@
 package domain
 
-import 	(
+import (
 	"github.com/amit-davidson/Chronos/utils/stacks"
 )
 
@@ -13,18 +13,18 @@ type Context struct {
 
 func NewEmptyContext() *Context {
 	return &Context{
-		Clock:                VectorClock{},
-		GoroutineID:          GoroutineCounter.GetNext(),
-		StackTrace:           stacks.NewIntStackWithMap(),
+		Clock:       VectorClock{},
+		GoroutineID: GoroutineCounter.GetNext(),
+		StackTrace:  stacks.NewIntStackWithMap(),
 	}
 }
 
 func NewGoroutineExecutionState(state *Context) *Context {
 	state.Increment()
 	return &Context{
-		Clock:                state.Clock,
-		GoroutineID:          GoroutineCounter.GetNext(),
-		StackTrace:           state.StackTrace,
+		Clock:       state.Clock,
+		GoroutineID: GoroutineCounter.GetNext(),
+		StackTrace:  state.StackTrace,
 	}
 }
 
@@ -44,8 +44,16 @@ func (gs *Context) MayConcurrent(state *Context) bool {
 
 func (gs *Context) Copy() *Context {
 	return &Context{
-		GoroutineID:          gs.GoroutineID,
-		Clock:                gs.Clock.Copy(),
-		StackTrace:           gs.StackTrace.Copy(),
+		GoroutineID: gs.GoroutineID,
+		Clock:       gs.Clock.Copy(),
+		StackTrace:  gs.StackTrace.Copy(),
+	}
+}
+
+func (gs *Context) CopyWithoutMap() *Context {
+	return &Context{
+		GoroutineID: gs.GoroutineID,
+		Clock:       gs.Clock.Copy(),
+		StackTrace:  stacks.NewIntStackWithMapWithParams(*gs.StackTrace.GetItems().Copy(), nil),
 	}
 }

--- a/domain/FunctionState.go
+++ b/domain/FunctionState.go
@@ -45,14 +45,9 @@ func (fs *FunctionState) AddContextToFunction(context *Context) {
 		ga.State.GoroutineID = context.GoroutineID
 		context.Increment()
 
-
 		relativePos := ga.State.StackTrace.Iter()[ga.PosToRemove+1:]
-		a := stacks.NewIntStackWithMap()
-		for _, item := range relativePos {
-			a.Push(item)
-		}
-		tmpContext := context.Copy()
-		tmpContext.StackTrace.Merge(a)
+		tmpContext := context.CopyWithoutMap()
+		tmpContext.StackTrace.GetItems().MergeStacks((*stacks.IntStack)(&relativePos))
 		ga.State.StackTrace = tmpContext.StackTrace
 		ga.State.Clock = tmpContext.Clock
 	}

--- a/domain/GuardedAccess.go
+++ b/domain/GuardedAccess.go
@@ -25,26 +25,28 @@ func (op OpKind) String() string {
 }
 
 type GuardedAccess struct {
-	ID          int // ID depends on the flow, which means it's unique.
 	PosID       int // guarded accesses of the same function share the same PosID. It's used to mark the same guarded access in different flows.
 	Pos         token.Pos
-	PosToRemove int
+	OpKind      OpKind
 	Value       ssa.Value
+
+	PosToRemove int
+	ID          int // ID depends on the flow, which means it's unique.
 	State       *Context
 	Lockset     *Lockset
-	OpKind      OpKind
 }
 
 func (ga *GuardedAccess) Copy() *GuardedAccess {
 	return &GuardedAccess{
+		PosID:  ga.PosID,
+		Pos:    ga.Pos,
+		Value:  ga.Value,
+		OpKind: ga.OpKind,
+
 		ID:          ga.ID,
-		PosID:       ga.PosID,
-		Pos:         ga.Pos,
 		PosToRemove: ga.PosToRemove,
-		Value:       ga.Value,
 		Lockset:     ga.Lockset.Copy(),
-		OpKind:      ga.OpKind,
-		State:       ga.State.Copy(),
+		State:       ga.State.CopyWithoutMap(),
 	}
 }
 
@@ -86,5 +88,5 @@ func (ga *GuardedAccess) Intersects(gaToCompare *GuardedAccess) bool {
 func AddGuardedAccess(pos token.Pos, value ssa.Value, kind OpKind, lockset *Lockset, context *Context) *GuardedAccess {
 	context.Increment()
 	return &GuardedAccess{ID: GuardedAccessCounter.GetNext(), PosID: PosIDCounter.GetNext(), Pos: pos,
-		Value: value, Lockset: lockset.Copy(), OpKind: kind, State: context.Copy()}
+		Value: value, Lockset: lockset.Copy(), OpKind: kind, State: context.CopyWithoutMap()}
 }

--- a/utils/stacks/intStack.go
+++ b/utils/stacks/intStack.go
@@ -5,14 +5,14 @@ type IntStackWithMap struct {
 	intMap IntMap
 }
 
-func NewIntStackWithMap() *IntStackWithMap {
+func NewEmptyIntStackWithMap() *IntStackWithMap {
 	stack := make([]int, 0, 20)
 	intMap := make(IntMap)
 	basicBlockStack := &IntStackWithMap{stack: stack, intMap: intMap}
 	return basicBlockStack
 }
 
-func NewIntStackWithMapWithParams(stack IntStack, intMap IntMap) *IntStackWithMap {
+func NewIntStackWithMap(stack IntStack, intMap IntMap) *IntStackWithMap {
 	basicBlockStack := &IntStackWithMap{stack: stack, intMap: intMap}
 	return basicBlockStack
 }

--- a/utils/stacks/intStack.go
+++ b/utils/stacks/intStack.go
@@ -6,8 +6,13 @@ type IntStackWithMap struct {
 }
 
 func NewIntStackWithMap() *IntStackWithMap {
-	stack := make([]int, 0)
+	stack := make([]int, 0, 20)
 	intMap := make(IntMap)
+	basicBlockStack := &IntStackWithMap{stack: stack, intMap: intMap}
+	return basicBlockStack
+}
+
+func NewIntStackWithMapWithParams(stack IntStack, intMap IntMap) *IntStackWithMap {
 	basicBlockStack := &IntStackWithMap{stack: stack, intMap: intMap}
 	return basicBlockStack
 }
@@ -51,7 +56,6 @@ func (s *IntStackWithMap) Pop() int {
 func (s *IntStackWithMap) Merge(sn *IntStackWithMap) {
 	for _, item := range sn.Iter() {
 		s.stack.Push(item)
-		s.intMap[item] = struct{}{}
 	}
 }
 


### PR DESCRIPTION
Guarded accesses have only int array as stack and not map.
Predefined pos stack to avoid calling to `slicegrowth` too much.