### PR TITLE
Pass module path to allow search packages not in working directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Usage of ./chronos:
   --file string
     	The file containing the entry point of the program
   --mod string
-    	Path to the module where the search should be performed. It needs to be in the format:{VCS}/{organization}/{package}. Packages outside this path are excluded rom the search.
+    	Absolute path to the module where the search should be performed. Should end in the format:{VCS}/{organization}/{package}. Packages outside this path are excluded rom the search.
 ```
 
 ## Example:

--- a/cmd/chronos/main.go
+++ b/cmd/chronos/main.go
@@ -28,13 +28,17 @@ func main() {
 	domain.GuardedAccessCounter = utils.NewCounter()
 	domain.PosIDCounter = utils.NewCounter()
 
-	ssaProg, ssaPkg, err := ssaUtils.LoadPackage(*defaultFile)
+	ssaProg, ssaPkg, err := ssaUtils.LoadPackage(*defaultFile, *defaultModulePath)
 	if err != nil {
 		fmt.Printf("Failed loading with the following error:%s\n", err)
 		os.Exit(1)
 	}
 	entryFunc := ssaPkg.Func("main")
-	ssaUtils.InitPreProcess(ssaProg, *defaultModulePath)
+	err = ssaUtils.InitPreProcess(ssaProg, *defaultModulePath)
+	if err != nil {
+		fmt.Print(err)
+		os.Exit(1)
+	}
 
 	entryCallCommon := ssa.CallCommon{Value: entryFunc}
 	functionState := ssaUtils.HandleCallCommon(domain.NewEmptyContext(), &entryCallCommon, entryFunc.Pos())

--- a/ssaUtils/PreProcess.go
+++ b/ssaUtils/PreProcess.go
@@ -1,9 +1,13 @@
 package ssaUtils
 
 import (
+	"errors"
 	"github.com/amit-davidson/Chronos/utils/stacks"
 	"go/types"
 	"golang.org/x/tools/go/ssa"
+	"os"
+	"path"
+	"strings"
 )
 
 type FunctionWithLocksPreprocess struct {
@@ -12,7 +16,15 @@ type FunctionWithLocksPreprocess struct {
 	visitedFuncs      *stacks.FunctionStackWithMap
 }
 
-func InitPreProcess(prog *ssa.Program, defaultModulePath string) {
+func InitPreProcess(prog *ssa.Program, defaultModulePath string) error {
 	GlobalProgram = prog
-	GlobalModuleName = defaultModulePath
+	p := strings.TrimSuffix(defaultModulePath, string(os.PathSeparator))
+	splittedPath := strings.Split(p, string(os.PathSeparator))
+	if len(splittedPath) < 3 {
+		return errors.New("package should be provided in the following format:{VCS}/{organization}/{package}")
+	}
+	l := len(splittedPath)
+	moduleName := path.Join(splittedPath[l-3], splittedPath[l-2], splittedPath[l-1])
+	GlobalModuleName = moduleName
+	return nil
 }

--- a/ssaUtils/testutils.go
+++ b/ssaUtils/testutils.go
@@ -6,6 +6,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"go/constant"
 	"golang.org/x/tools/go/ssa"
+	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -64,10 +66,15 @@ func LoadMain(t *testing.T, filePath string) (*ssa.Function, *ssa.Package) {
 	domain.GuardedAccessCounter = utils.NewCounter()
 	domain.PosIDCounter = utils.NewCounter()
 
-	ssaProg, ssaPkg, err := LoadPackage(filePath)
+	_, ex, _, ok := runtime.Caller(0)
+	require.True(t, ok)
+	modulePath := filepath.Dir(filepath.Dir(ex))
+
+	ssaProg, ssaPkg, err := LoadPackage(filePath, modulePath)
 	require.NoError(t, err)
 	f := ssaPkg.Func("main")
-	InitPreProcess(ssaProg, "github.com/amit-davidson/Chronos")
+	err = InitPreProcess(ssaProg, modulePath)
+	require.NoError(t, err)
 	return f, ssaPkg
 }
 


### PR DESCRIPTION
Change --mod to require an absolute path. This way it's possible to tell where the working directory is and also get the module name. It should allow the tool to run outside the working directory. 